### PR TITLE
Update site configuration to work on Github Pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ description: > # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
-baseurl: "" # the subpath of your site, e.g. /blog/
+baseurl: "/ChinaStartupWeekendOrg/" # the subpath of your site, e.g. /blog/
 url: "http://yourdomain.com" # the base hostname & protocol for your site
 twitter_username: jekyllrb
 github_username:  jekyll


### PR DESCRIPTION
All of your asset calls are relative to whatever the `baseurl` value is, such as in [this line](https://github.com/StartupWeekendChina/ChinaStartupWeekendOrg/blob/gh-pages/_includes/head.html#L6) of your header.

Because you created the site within its own repo, you end up getting it hosted under a path on the sub-domain.

The above fix _should_ update your asset calls to load from the path rather than from the sub-domain root.
